### PR TITLE
use disused importGameCaveat2 key

### DIFF
--- a/app/views/game/importGame.scala
+++ b/app/views/game/importGame.scala
@@ -53,6 +53,9 @@ object importGame:
             help = Some(analyseHelp),
             disabled = ctx.isAnon
           ),
+                             a(cls := "text", dataIcon := licon.InfoCircle, href := routes.Study.allDefault(1)):
+            trans.importGameCaveat2()
+          ,
           form3.action(form3.submit(trans.importGame(), licon.UploadCloud.some))
         )
       )


### PR DESCRIPTION


I used the wrong key at the bottom of the page last time, but now I am using the second caveat not the first at the bottom of the page.